### PR TITLE
fix retry and add test for same

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,6 @@
 # rems-co
 
-**rems-co** is a lightweight bridge service that enables entitlement events from the [REMS]
-(https://github.com/CSCfi/rems) Resource Entitlement Management System to be reflected in real
+**rems-co** is a lightweight bridge service that enables entitlement events from the [REMS](https://github.com/CSCfi/rems) Resource Entitlement Management System to be reflected in real
 time as group membership changes within a COmanage Registry. When a user is approved for access
 to a resource in REMS, **rems-co** ensures the user is added to the corresponding group in
 COmanage; when access is revoked, the user is removed.

--- a/src/rems_co/comanage_api/client.py
+++ b/src/rems_co/comanage_api/client.py
@@ -47,7 +47,7 @@ def retry_policy() -> Any:
     return retry(
         stop=stop_after_attempt(settings.comanage_retry_attempts),
         wait=wait_exponential(
-            multiplier=settings.comanage_retry_backoff, min=1, max=30
+            multiplier=settings.comanage_retry_backoff, min=1, max=10
         ),
         retry=retry_if_exception_type(httpx.RequestError),
         reraise=True,
@@ -83,8 +83,8 @@ class CoManageClient:
                 response=e.response,
             ) from e
         except httpx.RequestError as e:
-            logger.error(f"Request error from COmanage: {e}", exc_info=True)
-            raise COmanageAPIError(f"{method.upper()} {path} failed: {e}") from e
+            logger.error(f"Request error from COmanage: {e}")
+            raise
 
     @retry_policy()
     def _get(self, path: str, **kwargs: Any) -> httpx.Response:

--- a/src/rems_co/settings.py
+++ b/src/rems_co/settings.py
@@ -20,7 +20,9 @@ class Settings(BaseSettings):
     comanage_retry_attempts: int = Field(
         3, description="Max retry attempts for COmanage API"
     )
-    comanage_retry_backoff: float = Field(3, description="Backoff multiplier")
+    comanage_retry_backoff: float = Field(
+        1, description="Exponential backoff multiplier"
+    )
     create_groups_for_resources: list[str] = ["*"]  # Default: all resources
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")


### PR DESCRIPTION
Previously `CoManageClient._request` was wrapping `RequestError` so it was never being retried on as per the policy